### PR TITLE
Support mouse relative mode via submission queue

### DIFF
--- a/src/i_system.h
+++ b/src/i_system.h
@@ -24,6 +24,9 @@
 #ifndef __I_SYSTEM__
 #define __I_SYSTEM__
 
+#include <stdint.h>
+#include <stdlib.h>
+
 #include "d_ticcmd.h"
 #include "d_event.h"
 
@@ -31,6 +34,26 @@
 #pragma interface
 #endif
 
+enum {
+	RELATIVE_MODE_SUBMISSION = 0,
+};
+
+typedef struct {
+	uint32_t type;
+	union {
+		union {
+			uint8_t enabled;
+		} mouse;
+	};
+} emu_submission_t;
+
+typedef struct {
+	emu_submission_t *base;
+	size_t end;
+} submission_queue_t;
+
+extern submission_queue_t submission_queue;
+extern const int queues_capacity;
 
 // Called by DoomMain.
 void I_Init (void);

--- a/src/m_menu.c
+++ b/src/m_menu.c
@@ -512,6 +512,17 @@ static inline void M_DrawPatchInternal (int x, int y, int scrn, patch_t *patch)
     V_DrawPatchDirect (x, y, scrn, patch);
 }
 
+static inline void M_SetRelativeMode(boolean enabled) {
+	emu_submission_t submission;
+	submission.type = RELATIVE_MODE_SUBMISSION;
+	submission.mouse.enabled = enabled;
+	submission_queue.base[submission_queue.end++] = submission;
+	submission_queue.end &= queues_capacity - 1;
+	register int a0 asm("a0") = 1;
+	register int a7 asm("a7") = 0xfeed;
+	asm volatile("scall" : "+r"(a0) : "r"(a7));
+}
+
 //
 // M_ReadSaveStrings
 //  read the strings from the savegame files
@@ -1700,6 +1711,7 @@ void M_StartControlPanel (void)
         return;
 
     menuactive = 1;
+    M_SetRelativeMode(false);
     currentMenu = &MainDef;         // JDC
     itemOn = currentMenu->lastOn;   // JDC
 }
@@ -1784,6 +1796,7 @@ void M_Drawer (void)
 void M_ClearMenus (void)
 {
     menuactive = 0;
+    M_SetRelativeMode(true);
     // if (!netgame && usergame && paused)
     //       sendpause = true;
 }


### PR DESCRIPTION
This commit adds support for automatic mouse capture control via the new submission queue feature. With this modification, the cursor will be captured when the the game screen is on the top layer and released when the menu is opened.