### PR TITLE
Support mouse relative mode via submission queue

### DIFF
--- a/src/i_system.h
+++ b/src/i_system.h
@@ -89,6 +89,7 @@ void I_Tactile (int on, int off, int total);
 
 void I_Error (char *error, ...);
 
+void I_SetRelativeMode(boolean enabled);
 
 #endif
 //-----------------------------------------------------------------------------

--- a/src/m_menu.c
+++ b/src/m_menu.c
@@ -1700,6 +1700,7 @@ void M_StartControlPanel (void)
         return;
 
     menuactive = 1;
+    I_SetRelativeMode(false);
     currentMenu = &MainDef;         // JDC
     itemOn = currentMenu->lastOn;   // JDC
 }
@@ -1784,6 +1785,7 @@ void M_Drawer (void)
 void M_ClearMenus (void)
 {
     menuactive = 0;
+    I_SetRelativeMode(true);
     // if (!netgame && usergame && paused)
     //       sendpause = true;
 }


### PR DESCRIPTION
This commit adds support for automatic mouse capture control via the new submission queue feature. With this modification, the cursor will be captured once the game screen become visible and be released when the menu is opened.