### PR TITLE
Disconnect character movement from the mouse movements

### DIFF
--- a/src/g_game.c
+++ b/src/g_game.c
@@ -403,7 +403,6 @@ void G_BuildTiccmd (ticcmd_t* cmd)
         }
     }
 
-    forward += mousey;
     if (strafe)
         side += mousex*2;
     else


### PR DESCRIPTION
The character could be moved forward or backward by dragging the mouse. However, since the keyboard has already been assigned to handle character movement, playing the game with both the mouse and keyboard may be rather annoying. Thus, it should no longer be possible to move using a mouse.