### PR TITLE
Reduce DOOM memory use

### DIFF
--- a/src/doomdef.h
+++ b/src/doomdef.h
@@ -29,10 +29,19 @@
 
 // Disable screens wipe effect, you will get worse game experience, 
 // but it can save about 130KB on DOOMHEAP.
+// In f_wipe.c, only wipe_initMelt() and wipe_shittyColMajorXform() call Z_Malloc ask for some sapce,
+// wipe_initMelt() ask 320 * 8(width * sizeof(int)) = 2560 bytes,
+// wipe_shittyColMajorXform() ask 160 * 200 * 2(width/2 * height*2) = 64000 bytes,
+// it will be call twice so it will totaly ask 128000 bytes,
+// it means we can save 2560 + 128000 = 130560 bytes on DOOMHEAP when disable screens wipe.
 #define DISABLE_WIPES
 
 // Discard screen buffers, any screen effect will direct output on your screen, 
-// It can save 192kb on heap. 
+// It can save 192kb memory usage.
+// Each screen buffer is 320 * 200 * 1 = 64000 bytes, 
+// COMBINE_SCREENS will make four screen buffers merge to one,
+// so we can save (4 - 1) * 320 * 200 = 192000 bytes.
+// In this Implement it will set "CombinedScreens[SCREENWIDTH*SCREENHEIGHT]" to replace original "CombinedScreens[SCREENWIDTH*SCREENHEIGHT*4]".
 // Remeber you can only use this when disable screens wipe.
 #define COMBINE_SCREENS
 

--- a/src/doomdef.h
+++ b/src/doomdef.h
@@ -27,6 +27,15 @@
 #include <stdio.h>
 #include <string.h>
 
+// Disable screens wipe effect, you will get worse game experience, 
+// but it can save about 130KB on DOOMHEAP.
+#define DISABLE_WIPES
+
+// Discard screen buffers, any screen effect will direct output on your screen, 
+// It can save 192kb on heap. 
+// Remeber you can only use this when disable screens wipe.
+#define COMBINE_SCREENS
+
 // The packed attribute forces structures to be packed into the minimum
 // space necessary.  If this is not done, the compiler may align structure
 // fields differently to optimise memory access, inflating the overall

--- a/src/f_wipe.c
+++ b/src/f_wipe.c
@@ -46,7 +46,7 @@ static byte*    wipe_scr_start;
 static byte*    wipe_scr_end;
 static byte*    wipe_scr;
 
-
+#ifndef DISABLE_WIPES
 void
 wipe_shittyColMajorXform
 ( short*        array,
@@ -233,6 +233,7 @@ wipe_exitMelt
     Z_Free(y);
     return 0;
 }
+#endif
 
 int
 wipe_StartScreen
@@ -246,6 +247,7 @@ wipe_StartScreen
     return 0;
 }
 
+#ifndef DISABLE_WIPES
 int
 wipe_EndScreen
 ( int   x,
@@ -301,3 +303,18 @@ wipe_ScreenWipe
     return !go;
 
 }
+#else
+int
+wipe_ScreenWipe
+( int	wipeno,
+  int	x,
+  int	y,
+  int	width,
+  int	height,
+  int	ticks )
+{
+	//Because we don't need wipe effct, just move screens[3] to screens[0]
+	memcpy( screens[0], wipe_scr_end, width*height );
+	return 1;
+}
+#endif

--- a/src/riscv/i_system.c
+++ b/src/riscv/i_system.c
@@ -39,6 +39,21 @@
 
 #include "console.h"
 
+#ifdef COMBINE_SCREENS
+unsigned char CombinedScreens[SCREENWIDTH*SCREENHEIGHT];
+#else
+unsigned char CombinedScreens[SCREENWIDTH*SCREENHEIGHT*4];
+#endif
+
+/* Original 6M - wipe function (130560 bytes) */
+#ifdef DISABLE_WIPES
+#define DOOM_HEAP_SIZE  6*1024*1024 - 130560
+#else
+#define DOOM_HEAP_SIZE  6*1024*1024
+#endif
+
+unsigned char DOOMHeap[DOOM_HEAP_SIZE];
+
 enum {
 	KEY_EVENT = 0,
 	MOUSE_MOTION_EVENT = 1,
@@ -139,9 +154,9 @@ I_Init(void)
 byte *
 I_ZoneBase(int *size)
 {
-	/* Give 6M to DOOM */
-	*size = 6 * 1024 * 1024;
-	return (byte *) malloc (*size);
+	/* Give DOOM_HEAP_SIZE to DOOM */
+	*size = DOOM_HEAP_SIZE;
+	return (byte *) DOOMHeap;
 }
 
 
@@ -313,8 +328,11 @@ I_Quit(void)
 byte *
 I_AllocLow(int length)
 {
-	/* FIXME: check if memory allocation succeeds */
-	return calloc(1, length);
+	/* Return screen buffer */
+	byte*	mem;
+	mem = CombinedScreens;
+	memset (mem,0,length);
+	return mem;
 }
 
 

--- a/src/riscv/i_system.c
+++ b/src/riscv/i_system.c
@@ -40,9 +40,9 @@
 #include "console.h"
 
 #ifdef COMBINE_SCREENS
-unsigned char CombinedScreens[SCREENWIDTH*SCREENHEIGHT];
+static unsigned char CombinedScreens[SCREENWIDTH*SCREENHEIGHT];
 #else
-unsigned char CombinedScreens[SCREENWIDTH*SCREENHEIGHT*4];
+static unsigned char CombinedScreens[SCREENWIDTH*SCREENHEIGHT*4];
 #endif
 
 /* Original 6M - wipe function (130560 bytes) */
@@ -52,7 +52,7 @@ unsigned char CombinedScreens[SCREENWIDTH*SCREENHEIGHT*4];
 #define DOOM_HEAP_SIZE  6*1024*1024
 #endif
 
-unsigned char DOOMHeap[DOOM_HEAP_SIZE];
+static unsigned char DOOMHeap[DOOM_HEAP_SIZE];
 
 enum {
 	KEY_EVENT = 0,

--- a/src/v_video.c
+++ b/src/v_video.c
@@ -463,9 +463,16 @@ void V_Init (void)
     byte*       base;
 
     // stick these in low dos memory on PCs
-
+    
+#ifndef COMBINE_SCREENS
     base = I_AllocLow (SCREENWIDTH*SCREENHEIGHT*4);
 
     for (i=0 ; i<4 ; i++)
         screens[i] = base + i*SCREENWIDTH*SCREENHEIGHT;
+#else
+    base = I_AllocLow (SCREENWIDTH*SCREENHEIGHT);
+
+    for (i=0 ; i<4 ; i++)
+        screens[i] = base;
+#endif
 }


### PR DESCRIPTION
Follow by [embeddedDOOM](https://github.com/cnlohr/embeddedDOOM)
I cut wipe function and combine screen.
cut wipe function can save  130560 bytes on heep.
combine screen,  if we cut wipe function it mean we don't need screen buffer 2 and 3, and screen buffer 1 can be abandon by worse game experience, so we only use screen buffer 0 to output, this way we can save 192000 bytes.
I set DISABLE_WIPES flag for cut wipe, COMBINE_SCREENS for combine screen. both flag define in doomdef.h.
By the way saving game will using screen buffer 3 for saving some information, if you want use combine screen you should add extra space for saving game.

below is my improve in reduce DOOM memory use 
original game size
    text	   data	    bss	    dec	    hex	filename
 546200	  86324	8633373	9265897	 8d62e9	doom-riscv.elf

my implement(combine screen + cut wipe function)
   text	   data	    bss	    dec	    hex	filename
 545352	  86324	7811601	8443277	 80d589	doom-riscv.elf




